### PR TITLE
Re-export AuctionHouseProgram

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holaplex/marketplace-js-sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Holaplex Marketplace Standard Actions for the Metaplex Auction House program",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from "./marketplace";
 export * from "./listings";
 export * from "./offers";
 export * from "./escrow";
+export { AuctionHouseProgram } from "@metaplex-foundation/mpl-auction-house";


### PR DESCRIPTION
### Changes
- Export the AuctionHouseProgram from the sdk so the pda functions can be accessed by a app using the sdk