### PR TITLE
Use new `market` subdomain

### DIFF
--- a/src/ipfs.ts
+++ b/src/ipfs.ts
@@ -15,7 +15,7 @@ const ipfsSDK = {
     console.log('file', file)
     body.append(file.name, file, file.name)
     try {
-      const resp = await fetch('https://www.holaplex.com/api/ipfs/upload', {
+      const resp = await fetch('https://market.holaplex.com/api/ipfs/upload', {
         method: 'POST',
         body,
       })


### PR DESCRIPTION
`www` no longer serves marketplace resources/api, use new `market` subdomain